### PR TITLE
Allow anonymous connection with username and empty password

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Plugin can be used with GUI or specifying parameters in `~/abNinjam/connection.p
 - `autoRemoteVolume=true`
 - `autoSyncBpm=true`
 
+Leaving `pass` empty will connect anonymously (if the server permits) and `user` is used as the nickname.
 autoLicenseAgree property is used to automatically agree to the license provided by the server (for example if you use your own server and know the license) (default: false).  
 autoRemoteVolume is set for adjusting remote channel volume by distributing it and protecting from clipping (default: true).  
 autoSyncBpm enables sending OSC message `/tempo/raw {int}` to host to change it's BPM if BPM is changed on Ninjam server. As well as sending /bpm command or voting command to change BPM for Ninjam server if BPM is changed on host. (default: true)

--- a/common/src/ninjamclient.cpp
+++ b/common/src/ninjamclient.cpp
@@ -132,6 +132,12 @@ NinjamClient::connect(ConnectionProperties *connectionProperties) {
 
   if (isEmpty(connectionProperties->gsUsername())) {
     connectionProperties->gsUsername() = strdup("anonymous");
+  } else {
+    if (isEmpty(connectionProperties->gsPassword())) {
+      string anonUser = string("anonymous:");
+      anonUser.append(connectionProperties->gsUsername());
+      connectionProperties->gsUsername() = strdup(anonUser.c_str());
+    }
   }
 
   agree = 1;


### PR DESCRIPTION
The method of connecting anonymously with a display name using `anonymous:myname` isn't well documented and I find it more intuitive to enter only a name to connect as a guest without login.