### PR TITLE
fix "anonymous:anonymous:..." username after reconnect

### DIFF
--- a/common/src/ninjamclient.cpp
+++ b/common/src/ninjamclient.cpp
@@ -133,8 +133,10 @@ NinjamClient::connect(ConnectionProperties *connectionProperties) {
   if (isEmpty(connectionProperties->gsUsername())) {
     connectionProperties->gsUsername() = strdup("anonymous");
   } else {
-    if (isEmpty(connectionProperties->gsPassword())) {
-      string anonUser = string("anonymous:");
+    const char *anonPrefix = "anonymous:";
+    if (isEmpty(connectionProperties->gsPassword())
+        && strncmp(connectionProperties->gsUsername(), anonPrefix, strlen(anonPrefix)) != 0) {
+      string anonUser = string(anonPrefix);
       anonUser.append(connectionProperties->gsUsername());
       connectionProperties->gsUsername() = strdup(anonUser.c_str());
     }


### PR DESCRIPTION
Sorry, just found a bug in my last PR #10 that happens when you reconnect as an anonymous user, in which case it would prepend "anonymous:" again so you get "anonymous:anonymous:name" and so on.

Also thanks for the quick response :)