### PR TITLE
Feature: Voice chat mode

### DIFF
--- a/common/include/ninjamclient.h
+++ b/common/include/ninjamclient.h
@@ -39,19 +39,22 @@ public:
   auto &gsNjClient() { return njClient; }
   auto &gsStopConnectionThread() { return stopConnectionThread; }
   auto &gsMtx() { return mtx; }
+  auto &gsUpdateChannelInfo() { return updateChannelInfo; }
   bool connected = false;
+  bool voiceChatMode = false;
   void clearBuffers(float **buf, int nch, int len);
   void adjustVolume();
   void setBpm(int bpm);
   std::vector<RemoteUser> getRemoteUsers();
   void setUserChannelVolume(int userId, int channelId, float volume);
   void setLocalChannelVolume(int channelId, float volume);
+  void setVoiceChat(bool toggle);
   void sendChatMessage(std::string message);
 
 private:
   std::thread *connectionThread;
   NJClient *njClient = new NJClient;
-  bool stopConnectionThread, autoRemoteVolume;
+  bool stopConnectionThread, autoRemoteVolume, updateChannelInfo;
   std::mutex mtx;
 };
 

--- a/lv2/abNinjam.ttl.in
+++ b/lv2/abNinjam.ttl.in
@@ -85,4 +85,15 @@
                 lv2:maximum 1;
                 lv2:default 1;
                 lv2:portProperty pprops:hasStrictBounds;
-        ].
+        ],
+	[
+		a lv2:ControlPort, lv2:InputPort;
+                lv2:index 7;
+	    	lv2:symbol "voicechat";
+	    	lv2:name "Voice Chat Mode";
+	    	lv2:minimum 0;
+                lv2:maximum 1;
+                lv2:default 0;
+                lv2:portProperty pprops:hasStrictBounds;
+                lv2:portProperty lv2:toggled;
+	].

--- a/lv2/include/ports.h
+++ b/lv2/include/ports.h
@@ -11,7 +11,8 @@ enum {
   INPUT_RIGHT = 3,
   CONNECT = 4,
   METRONOME_VOLUME = 5,
-  MONITOR_VOLUME = 6
+  MONITOR_VOLUME = 6,
+  VOICE_CHAT = 7
 };
 
 }

--- a/lv2/src/abNinjam.cpp
+++ b/lv2/src/abNinjam.cpp
@@ -18,7 +18,7 @@ public:
   NinjamClient *ninjamClient;
   NinjamClientStatus ninjamClientStatus = disconnected;
   ConnectionProperties *connectionProperties;
-  float *connect, *metronomeVolume, *monitorVolume;
+  float *connect, *metronomeVolume, *monitorVolume, *voiceChat;
   float *output_buffers[2], *input_buffers[2];
   double sampleRate;
   AbNinjamPlugin() {
@@ -51,6 +51,9 @@ static void connectPort(LV2_Handle instance, uint32_t port, void *data) {
   case MONITOR_VOLUME:
     plugin->monitorVolume = static_cast<float *>(data);
     break;
+  case VOICE_CHAT:
+    plugin->voiceChat = static_cast<float *>(data);
+    break;
   case INPUT_LEFT:
     plugin->input_buffers[0] = static_cast<float *>(data);
     break;
@@ -77,6 +80,8 @@ static void run(LV2_Handle instance, uint32_t sample_count) {
 
     plugin_data->ninjamClient->setLocalChannelVolume(
         0, *plugin_data->monitorVolume);
+
+    plugin_data->ninjamClient->setVoiceChat(*plugin_data->voiceChat > 0.f);
 
     if (plugin_data->ninjamClientStatus != ok) {
       plugin_data->ninjamClientStatus =

--- a/vst/include/plugids.h
+++ b/vst/include/plugids.h
@@ -15,6 +15,7 @@ enum AbNinjamParams : Vst::ParamID {
   kParamConnectionIndicatorId = 1001,
   kParamMetronomeVolId = 1002,
   kParamTemplateSelectId = 1003,
+  kParamVoiceId = 1004,
   kParamSendChatMessageId = 2000,
   kParamZoomFactorId = 3000,
   kParamChannelVolumeId = 10000

--- a/vst/include/plugprocessor.h
+++ b/vst/include/plugprocessor.h
@@ -50,6 +50,7 @@ public:
 
 protected:
   int16 connectParam = 0;
+  int16 voiceParam = 0;
   int16 connectionIndicatorParam = 0;
   Vst::ParamValue metronomeVolumeParam = 0.5;
   Vst::ParamValue monitorVolumeParam = 1;
@@ -57,6 +58,7 @@ protected:
 
 private:
   void connectToServer(int16 value, ConnectionProperties *connectionProperties);
+  void setVoiceChatMode(int16 toggle);
   char *tCharToCharPtr(Steinberg::Vst::TChar *tChar);
   void sendNotification(std::string text);
   void sendChatMessageUpdate(std::string text);

--- a/vst/src/plugcontroller.cpp
+++ b/vst/src/plugcontroller.cpp
@@ -34,6 +34,10 @@ tresult PLUGIN_API PlugController::initialize(FUnknown *context) {
         STR16("Connection indicator"), STR16("Connected/Disconnected"), 1, 0,
         ParameterInfo::kIsReadOnly, AbNinjamParams::kParamConnectionIndicatorId,
         0, STR16("Connection"));
+    parameters.addParameter(STR16("Voice Chat Mode"), nullptr, 1, 0,
+                            ParameterInfo::kCanAutomate,
+                            AbNinjamParams::kParamVoiceId, 0,
+                            STR16("VoiceChat"));
 
     notificationLabel = nullptr;
     mixerScrollView = nullptr;
@@ -161,6 +165,11 @@ tresult PLUGIN_API PlugController::setComponentState(IBStream *state) {
   if (streamer.readInt8(connectState) == false)
     return kResultFalse;
   setParamNormalized(AbNinjamParams::kParamConnectId, connectState);
+
+  int8 voiceChatState = 0;
+  if (streamer.readInt8(voiceChatState) == false)
+    return kResultFalse;
+  setParamNormalized(AbNinjamParams::kParamVoiceId, voiceChatState);
 
   int8 connectionIndicatorState = 0;
   if (streamer.readInt8(connectionIndicatorState) == false)

--- a/vst/src/plugprocessor.cpp
+++ b/vst/src/plugprocessor.cpp
@@ -219,6 +219,7 @@ tresult PLUGIN_API PlugProcessor::process(Vst::ProcessData &data) {
               kResultTrue) {
             voiceParam = value > 0 ? 1 : 0;
             // set voice chat flag
+            setVoiceChatMode(voiceParam);
           }
           break;
         case AbNinjamParams::kBypassId:


### PR DESCRIPTION
**This PR is a draft and will be improved**

Ninjam supports a channel mode for "voice chat" that lets you temporarily disable the interval synchronization. This can easily be enabled by the channel flag 2  so I implemented this in `common` and `lv2` targets. Because this operates on the synchronized NinjamClient object and the connection thread permanently keeps a lock on its mutex (why?), I put it inside that thread.

First tests worked ok but it seems like it's not on par with ReaNinjam or JamTaba, these have maybe 200-400 ms latency in voice chat mode, while abNinjam is always much slower with 1-3 s (estimation, I didn't actually measure it yet). This problem only regards sending – receiving other people's voice chat audio is fast even in abNinjam.

Goals in the scope of this feature:
- [x] common method to toggle the voice chat flag
- [x] toggle available in LV2
- [ ] toggle available in VST3
- [ ] reduce outgoing latency

It would be awesome if anyone could test this feature on their side (e.g. together with other clients) and give any kind of feedback :)